### PR TITLE
Fix Vercel Caching

### DIFF
--- a/code/src/app/dashboard/maintenance/page.tsx
+++ b/code/src/app/dashboard/maintenance/page.tsx
@@ -13,6 +13,7 @@ async function getMaintenanceInfo() {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
+        "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
       },
     });
     const data = await response.json();

--- a/code/src/app/dashboard/maintenance/page.tsx
+++ b/code/src/app/dashboard/maintenance/page.tsx
@@ -13,7 +13,7 @@ async function getMaintenanceInfo() {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+        'Cache-Control': 'no-cache, no-store, max-age=0, must-revalidate',
       },
     });
     const data = await response.json();


### PR DESCRIPTION
Vercel's production servers behave differently than the test server you can run with npm run start. While the former caches certain responses by default for performance reasons, the latter does not do that.

To deactivate the caching for the response giving me the unwanted 304 Not Modified status, i simply added a Cache-Control-header with no-cache, no-store, max-age=0 and must-revalidate directives to it